### PR TITLE
Channel service

### DIFF
--- a/src/app.hooks.ts
+++ b/src/app.hooks.ts
@@ -33,7 +33,7 @@ function logResult (ctx: HookContext): HookContext {
   const { path, method, result } = ctx;
   const string = JSON.stringify(result);
   const length = 1500; // prevent exceedingly long result log messages.
-  const resultString = string.length < length ? string : string.substring(0, length - 3) + '...';
+  const resultString = string && (string.length < length ? string : string.substring(0, length - 3) + '...');
 
   logger.info(`${path}#${method} result: ${resultString}`);
   return ctx;

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -22,6 +22,7 @@ export default function (app: Application): void {
   }
 
   app.on('connection', (connection: any): void => {
+    logger.info('on connection', connection);
     // On a new real-time connection, add it to the anonymous channel
     app.channel('anonymous').join(connection);
   });

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -22,7 +22,10 @@ export default function (app: Application): void {
   }
 
   app.on('connection', (connection: any): void => {
-    logger.info('on connection', connection);
+    logger.info('on connection');
+    if (connection) {
+      logger.info(JSON.stringify(connection));
+    }
     // On a new real-time connection, add it to the anonymous channel
     app.channel('anonymous').join(connection);
   });

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -4,4 +4,4 @@ import { Application as ExpressFeathers } from '@feathersjs/express';
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServiceTypes {}
 // The application instance type that will be used everywhere else
-export type Application = ExpressFeathers<ServiceTypes>;
+export type Application = ExpressFeathers<ServiceTypes> & { channel: any };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -19,6 +19,7 @@ import sms from './api/sms/sms.service';
 
 // Websocket services
 import presentationWebsocket from './websocket/presentation/presentation.websocket.service';
+import channel from './websocket/channel/channel.websocket.service';
 
 export default function (app: Application): void {
   app.configure(sessionData);
@@ -35,4 +36,5 @@ export default function (app: Application): void {
   app.configure(email);
   app.configure(sms);
   app.configure(presentationWebsocket);
+  app.configure(channel);
 }

--- a/src/services/websocket/channel/channel.websocket.class.ts
+++ b/src/services/websocket/channel/channel.websocket.class.ts
@@ -22,6 +22,7 @@ export class ChannelService {
       } catch (e) {
         logger.error(`error joining channel ${channel}`);
         logger.error(e);
+        throw e;
       }
     }
   }

--- a/src/services/websocket/channel/channel.websocket.class.ts
+++ b/src/services/websocket/channel/channel.websocket.class.ts
@@ -16,8 +16,13 @@ export class ChannelService {
     logger.info(`channel: ${channel}`);
 
     if (connection) {
-      logger.info(`connection: ${JSON.stringify(connection)}`);
-      this.app.channel(channel).join(connection);
+      try {
+        logger.info(`connection: ${JSON.stringify(connection)}`);
+        this.app.channel(channel).join(connection);
+      } catch (e) {
+        logger.error(`error joining channel ${channel}`);
+        logger.error(e);
+      }
     }
   }
 

--- a/src/services/websocket/channel/channel.websocket.class.ts
+++ b/src/services/websocket/channel/channel.websocket.class.ts
@@ -8,7 +8,7 @@ interface ServiceOptions { }
 export class ChannelService {
   private app: Application;
   private options: ServiceOptions;
-  async create (data: { channel: string}, params: Params): Promise<void> {
+  async create (data: { channel: string}, params: Params): Promise<{ success: boolean }> {
     logger.info('channelService create');
     const { channel } = data;
     const { connection } = params;
@@ -19,12 +19,16 @@ export class ChannelService {
       try {
         logger.info(`connection: ${JSON.stringify(connection)}`);
         this.app.channel(channel).join(connection);
+
+        return { success: true };
       } catch (e) {
         logger.error(`error joining channel ${channel}`);
         logger.error(e);
         throw e;
       }
     }
+
+    return { success: false };
   }
 
   constructor (options: ServiceOptions = {}, app: Application) {

--- a/src/services/websocket/channel/channel.websocket.class.ts
+++ b/src/services/websocket/channel/channel.websocket.class.ts
@@ -8,6 +8,18 @@ interface ServiceOptions { }
 export class ChannelService {
   private app: Application;
   private options: ServiceOptions;
+
+  /**
+   * Add the client connection to a specified channel.
+   * If the channel does not exist, it will be created.
+   *
+   * Primarily used to re-join previous session channel after a disconnect
+   *
+   * @param {{ channel: string}} data
+   * @param {Params} params
+   * @returns {Promise<{ success: boolean }>}
+   * @memberof ChannelService
+   */
   async create (data: { channel: string}, params: Params): Promise<{ success: boolean }> {
     logger.info('channelService create');
     const { channel } = data;

--- a/src/services/websocket/channel/channel.websocket.class.ts
+++ b/src/services/websocket/channel/channel.websocket.class.ts
@@ -1,0 +1,28 @@
+import { Params } from '@feathersjs/feathers';
+import { Application } from '../../../declarations';
+import logger from '../../../logger';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ServiceOptions { }
+
+export class ChannelService {
+  private app: Application;
+  private options: ServiceOptions;
+  async create (data: { channel: string}, params: Params): Promise<void> {
+    logger.info('channelService create');
+    const { channel } = data;
+    const { connection } = params;
+
+    logger.info(`channel: ${channel}`);
+
+    if (connection) {
+      logger.info(`connection: ${JSON.stringify(connection)}`);
+      this.app.channel(channel).join(connection);
+    }
+  }
+
+  constructor (options: ServiceOptions = {}, app: Application) {
+    this.app = app;
+    this.options = options;
+  }
+}

--- a/src/services/websocket/channel/channel.websocket.service.ts
+++ b/src/services/websocket/channel/channel.websocket.service.ts
@@ -1,0 +1,15 @@
+import { ServiceAddons } from '@feathersjs/feathers';
+
+import { Application } from '../../../declarations';
+import { ChannelService } from './channel.websocket.class';
+
+// add this service to the service type index
+declare module '../../../declarations' {
+  interface ServiceTypes {
+    channel: ChannelService & ServiceAddons<any>
+  }
+}
+
+export default function (app: Application) {
+  app.use('/channel', new ChannelService({}, app));
+}

--- a/test/services/websocket/channel/channel.websocket.class.test.ts
+++ b/test/services/websocket/channel/channel.websocket.class.test.ts
@@ -1,0 +1,39 @@
+import { Application } from '../../../../src/declarations';
+import { ChannelService } from '../../../../src/services/websocket/channel/channel.websocket.class';
+
+describe('ChannelService', () => {
+  describe('create', () => {
+    let service: ChannelService;
+    let app: Application;
+    const mockJoin = jest.fn();
+    const mockChannel = jest.fn(() => ({
+      join: mockJoin
+    }));
+
+    beforeAll(() => {
+      app = {
+        channel: mockChannel
+      } as unknown as Application;
+      service = new ChannelService({}, app);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('adds the connection to the channel', async () => {
+      const data = {
+        channel: 'test'
+      };
+
+      const params = {
+        connection: { provider: 'socketio' }
+      };
+
+      await service.create(data, params);
+
+      expect(mockChannel).toBeCalledWith(data.channel);
+      expect(mockJoin).toBeCalledWith(params.connection);
+    });
+  });
+});

--- a/test/services/websocket/channel/channel.websocket.service.test.ts
+++ b/test/services/websocket/channel/channel.websocket.service.test.ts
@@ -1,0 +1,9 @@
+import generateApp from '../../../../src/app';
+
+describe('initializing the email service', () => {
+  it('registers with the app', async () => {
+    const app = await generateApp();
+    const service = app.service('channel');
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
- Adds `ChannelService` which allows a client to connect to a specific channel (used to reconnect to the existing/previous session channel after a disconnect)

- adds logging around channel/socket connections

- fixes an issue in the app level logs that was causing an error to be thrown if a service method returned `undefined` or `null`